### PR TITLE
Fixes ContainX/docker-volume-netshare#56

### DIFF
--- a/netshare/drivers/ceph.go
+++ b/netshare/drivers/ceph.go
@@ -62,7 +62,7 @@ func (n cephDriver) Mount(r volume.Request) volume.Response {
 		return volume.Response{Err: err.Error()}
 	}
 
-	if err := n.mountVolume(source, hostdir); err != nil {
+	if err := n.mountVolume(r.Name, source, hostdir); err != nil {
 		return volume.Response{Err: err.Error()}
 	}
 	n.mountm.Add(r.Name, hostdir)
@@ -109,10 +109,10 @@ func (n cephDriver) fixSource(r volume.Request) string {
 	return strings.Join(source, "/")
 }
 
-func (n cephDriver) mountVolume(source, dest string) error {
+func (n cephDriver) mountVolume(name, source, dest string) error {
 	var cmd string
 
-	options := n.mountOptions(n.mountm.GetOptions(dest))
+	options := n.mountOptions(n.mountm.GetOptions(name))
 	opts := ""
 	if val, ok := options[CephOptions]; ok {
 		fmt.Println("opts = ", val)
@@ -128,7 +128,7 @@ func (n cephDriver) mountVolume(source, dest string) error {
 	//cmd = fmt.Sprintf("%s -t ceph %s:%s:/ -o %s,%s,%s %s %s", mountCmd, n.cephmount, n.cephport, n.context, n.username, n.password, opts, dest)
 	cmd = fmt.Sprintf("%s -t ceph %s -o %s,%s,%s %s %s", mountCmd, source, n.context, n.username, n.password, opts, dest)
 
-	log.Debugf("exec: %s\n", cmd)
+	log.Debugf("exec: %s\n", strings.Replace(cmd, ","+n.password, ",****", 1))
 	return run(cmd)
 }
 

--- a/netshare/drivers/cifs.go
+++ b/netshare/drivers/cifs.go
@@ -84,7 +84,7 @@ func (c cifsDriver) Mount(r volume.Request) volume.Response {
 		return volume.Response{Err: err.Error()}
 	}
 
-	if err := c.mountVolume(source, hostdir, c.getCreds(host)); err != nil {
+	if err := c.mountVolume(r.Name, source, hostdir, c.getCreds(host)); err != nil {
 		return volume.Response{Err: err.Error()}
 	}
 	c.mountm.Add(r.Name, hostdir)
@@ -141,20 +141,20 @@ func (c cifsDriver) parseHost(r volume.Request) string {
 	return name
 }
 
-func (s cifsDriver) mountVolume(source, dest string, creds *CifsCreds) error {
+func (s cifsDriver) mountVolume(name, source, dest string, creds *CifsCreds) error {
 	var opts bytes.Buffer
 	var user = creds.user
 	var pass = creds.pass
 	var domain = creds.domain
 	var security = creds.security
 
-	options := merge(s.mountm.GetOptions(dest), s.cifsopts)
+	options := merge(s.mountm.GetOptions(name), s.cifsopts)
 	if val, ok := options[CifsOpts]; ok {
 		opts.WriteString(val + ",")
 	}
 
-	if s.mountm.HasOptions(dest) {
-		mopts := s.mountm.GetOptions(dest)
+	if s.mountm.HasOptions(name) {
+		mopts := s.mountm.GetOptions(name)
 		if v, found := mopts[UsernameOpt]; found {
 			user = v
 		}

--- a/netshare/drivers/nfs.go
+++ b/netshare/drivers/nfs.go
@@ -55,7 +55,7 @@ func (n nfsDriver) Mount(r volume.Request) volume.Response {
 		return volume.Response{Err: err.Error()}
 	}
 
-	if err := n.mountVolume(source, hostdir, n.version); err != nil {
+	if err := n.mountVolume(r.Name, source, hostdir, n.version); err != nil {
 		return volume.Response{Err: err.Error()}
 	}
 	n.mountm.Add(r.Name, hostdir)
@@ -102,10 +102,10 @@ func (n nfsDriver) fixSource(r volume.Request) string {
 	return strings.Join(source, "/")
 }
 
-func (n nfsDriver) mountVolume(source, dest string, version int) error {
+func (n nfsDriver) mountVolume(name, source, dest string, version int) error {
 	var cmd string
 
-	options := merge(n.mountm.GetOptions(dest), n.nfsopts)
+	options := merge(n.mountm.GetOptions(name), n.nfsopts)
 	opts := ""
 	if val, ok := options[NfsOptions]; ok {
 		opts = val


### PR DESCRIPTION
Use the registered name for a mount when looking for permissions that have been provided through options passed during the volume creation.