### PR TITLE
EFS volume id extractor added for compatibility with docker-compose

### DIFF
--- a/netshare/drivers/efs.go
+++ b/netshare/drivers/efs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/go-plugins-helpers/volume"
 	"os"
 	"strings"
+	"regexp"
 )
 
 const (
@@ -100,6 +101,9 @@ func (e efsDriver) Unmount(r volume.UnmountRequest) volume.Response {
 }
 
 func (e efsDriver) fixSource(name, id string) string {
+	reg, _ := regexp.Compile("(fs-[0-9a-f]+)$")
+	name = reg.FindString(name)
+
 	if e.mountm.HasOption(name, ShareOpt) {
 		name = e.mountm.GetOption(name, ShareOpt)
 	}


### PR DESCRIPTION
This fix allowing to use docker-volume-netshare with docker-compose ant his prefixes.

Situation to fix:

We are using docker compose to run application:
```
docker-compose -p ec2user_ up
```

As result we have mounting errors:
```
[ec2-user@ip-10-11-0-87 docker-volume-netshare]$ sudo ./docker-volume-netshare efs --verbose
INFO[0000] == docker-volume-netshare :: Version:  - Built:  ==
INFO[0000] Starting EFS :: availability-zone: , resolve: false, ns:
DEBU[0002] Entering Get: {ec2user_fs-4443b58d map[]}
DEBU[0002] Host path for ec2user_fs-4443b58d (ec2user_fs-4443b58d) is at /var/lib/docker-volumes/netshare/efs/ec2user_fs-4443b58d
DEBU[0002] Attempting to resolve: eu-west-1a.ec2user_fs-4443b58d.efs.eu-west-1.amazonaws.com
ERRO[0002] Error during resolve: Response was empty
INFO[0002] Mounting EFS volume eu-west-1a.ec2user_fs-4443b58d.efs.eu-west-1.amazonaws.com: on /var/lib/docker-volumes/netshare/efs/ec2user_fs-4443b58d
```

Error is appearing since docker adds prefix to container's and share's name.

**Proposed solution:**
Extract efs volume name from given string to remove prefix from it