### PR TITLE
fix mounting efs with subdirectory.

### DIFF
--- a/netshare/drivers/efs.go
+++ b/netshare/drivers/efs.go
@@ -2,11 +2,12 @@ package drivers
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
-	"os"
-	"strings"
-	"regexp"
 )
 
 const (
@@ -101,15 +102,14 @@ func (e efsDriver) Unmount(r volume.UnmountRequest) volume.Response {
 }
 
 func (e efsDriver) fixSource(name, id string) string {
-	reg, _ := regexp.Compile("(fs-[0-9a-f]+)$")
-	name = reg.FindString(name)
-
 	if e.mountm.HasOption(name, ShareOpt) {
 		name = e.mountm.GetOption(name, ShareOpt)
 	}
 
 	v := strings.Split(name, "/")
-	uri := v[0]
+	reg, _ := regexp.Compile("(fs-[0-9a-f]+)$")
+	uri := reg.FindString(v[0])
+
 	if e.resolve {
 		uri = fmt.Sprintf(EfsTemplateURI, e.availzone, v[0], e.region)
 		if i, ok := e.dnscache[uri]; ok {


### PR DESCRIPTION
`docker service create` crashes that mounting efs volume with subdirectory due to commit https://github.com/ContainX/docker-volume-netshare/commit/c3f4656e90bdef9276a6b810ac3cb036359edb08#diff-bbdb84b38e52cd4bfd6a51a4e0d802a3.

When I passed `fs-xxxxx/subdir/subdir` as source, name will be nil. And paths of subdirectories will be discarded.
This PR to made that fixSource returns `fs-id:/subdir/subdir`. But i can't convince that it is kept compatibility with docker-compose...



