### PR TITLE
Fix for the invalid socket name

### DIFF
--- a/netshare/netshare.go
+++ b/netshare/netshare.go
@@ -230,7 +230,7 @@ func start(dt drivers.DriverType, driver volume.Driver) {
 		}
 		fmt.Println(h.ServeTCP(dt.String(), addr, nil))
 	} else {
-		fmt.Println(h.ServeUnix("", int(dt)))
+		fmt.Println(h.ServeUnix(dt.String(), int(dt)))
 	}
 }
 


### PR DESCRIPTION
The first parameter of the ServeUnix method is used as filename for the socket (without extension, which is added later). This is a fix for: https://github.com/ContainX/docker-volume-netshare/issues/97
