### PR TITLE
Fixes to problems with reference counting nfs mounts.

### DIFF
--- a/netshare/drivers/mounts.go
+++ b/netshare/drivers/mounts.go
@@ -141,7 +141,7 @@ func (m *mountManager) Increment(name string) int {
 
 func (m *mountManager) Decrement(name string) int {
 	c, found := m.mounts[name]
-	if found {
+	if found && c.connections > 0 {
 		c.connections--
 	}
 	return 0

--- a/netshare/drivers/nfs.go
+++ b/netshare/drivers/nfs.go
@@ -56,10 +56,10 @@ func (n nfsDriver) Mount(r volume.MountRequest) volume.Response {
 
 	if n.mountm.HasMount(resolvedName) && n.mountm.Count(resolvedName) > 0 {
 		log.Infof("Using existing NFS volume mount: %s", hostdir)
-		n.mountm.Increment(resolvedName)
 		if err := run(fmt.Sprintf("mountpoint -q %s", hostdir)); err != nil {
 			log.Infof("Existing NFS volume not mounted, force remount.")
 		} else {
+			n.mountm.Increment(resolvedName)
 			return volume.Response{Mountpoint: hostdir}
 		}
 	}
@@ -74,10 +74,11 @@ func (n nfsDriver) Mount(r volume.MountRequest) volume.Response {
 		n.mountm.Create(resolvedName, hostdir, resOpts)
 	}
 
+	n.mountm.Add(resolvedName, hostdir)
+	
 	if err := n.mountVolume(resolvedName, source, hostdir, n.version); err != nil {
 		return volume.Response{Err: err.Error()}
 	}
-	n.mountm.Add(resolvedName, hostdir)
 
 	if n.mountm.GetOption(resolvedName, ShareOpt) != "" && n.mountm.GetOptionAsBool(resolvedName, CreateOpt) {
 		log.Infof("Mount: Share and Create options enabled - using %s as sub-dir mount", resolvedName)


### PR DESCRIPTION
Fixes described here: https://github.com/ContainX/docker-volume-netshare/issues/106

Partially fixes reference counting issues found after during debugging. A more complete fix is described in the issue report.

Test cases:
1. Mount an already mounted nfs volume with root squashing enabled and observe ref count increment by 2. This is because the "mountpoint" command fails if service is run as root with root squashing enabled on nfs filer, so enters the if condition on line 69.
2. Attempt to mount a volume that fails (no permissions or doesn't exist) and observe ref count stays at 0. When unmounted observe ref count drops below 0.
3. Restart docker-volume-netshare while container with mounted volume is running. Start and stop new container mounting same volume after restart, then stop first container. Observe ref count drop below zero.
