### PR TITLE
Fix to problem where data on NFS mounts is deleted when mounting nest…

### DIFF
--- a/netshare/drivers/nfs.go
+++ b/netshare/drivers/nfs.go
@@ -119,9 +119,13 @@ func (n nfsDriver) Unmount(r volume.UnmountRequest) volume.Response {
 
 	n.mountm.DeleteIfNotManaged(resolvedName)
 
-	if err := os.RemoveAll(hostdir); err != nil {
-		return volume.Response{Err: err.Error()}
-	}
+        // Check if directory is empty. This command will return "err" if empty
+        if err := run(fmt.Sprintf("ls -1 %s | grep .", hostdir)); err == nil {
+                log.Warnf("Directory %s not empty after unmount. Skipping RemoveAll call.", hostdir)
+        } else {
+                if err := os.RemoveAll(hostdir); err != nil {
+                      return volume.Response{Err: err.Error()}
+        }
 
 	return volume.Response{}
 }

--- a/netshare/drivers/nfs.go
+++ b/netshare/drivers/nfs.go
@@ -125,6 +125,7 @@ func (n nfsDriver) Unmount(r volume.UnmountRequest) volume.Response {
         } else {
                 if err := os.RemoveAll(hostdir); err != nil {
                       return volume.Response{Err: err.Error()}
+		}
         }
 
 	return volume.Response{}


### PR DESCRIPTION
…ed volumes.

Fixes issue: https://github.com/ContainX/docker-volume-netshare/issues/104

Test case: 
1. Run container that mounts nfs volume on host:/a/b
2. Run container that mounts nfs volume on host:/a
3. Stop container that mounts host:/a
4. Observe that data goes missing under /a/b

Note that RemoveAll will stop deleting files as soon as it encounters an error, and it will encounter an error when it tries to remove directory b (because it is mounted), so in some cases you may not see complete data loss or even any data loss, it is dependent on whether or not any files were deleted prior to hitting an error.

An alternative fix here would be to use an os method (if any) that simply removes the directory. Essentially replace "rm -rf" with "rmdir".

Additionally, directories skipped from removal here will not get cleaned up until another container mounts them, leaving a empty directories on the host machine. These directories are small so are not a major concern, however a more proper fix would clean these up when possible.