### PR TITLE
Fix to issue with mounting nfs volumes with root squashing enabled.

### DIFF
--- a/netshare/drivers/nfs.go
+++ b/netshare/drivers/nfs.go
@@ -57,7 +57,7 @@ func (n nfsDriver) Mount(r volume.MountRequest) volume.Response {
 	if n.mountm.HasMount(resolvedName) && n.mountm.Count(resolvedName) > 0 {
 		log.Infof("Using existing NFS volume mount: %s", hostdir)
 		n.mountm.Increment(resolvedName)
-		if err := run(fmt.Sprintf("mountpoint -q %s", hostdir)); err != nil {
+		if err := run(fmt.Sprintf("grep -c %s /proc/mounts", hostdir)); err != nil {
 			log.Infof("Existing NFS volume not mounted, force remount.")
 		} else {
 			return volume.Response{Mountpoint: hostdir}


### PR DESCRIPTION
Fixes issue: https://github.com/ContainX/docker-volume-netshare/issues/109

Test case:
1. Enable root squashing on an nfs filer.
2. Start a docker container that mounts a volume on that filer.
3. Start another docker container that mounts the same volume.
Observe that the existing volume is not used, instead it tries to "force remount" which fails, causing the job to fail to start.
