### PR TITLE
Fix debian inits scripts so they are usable at boot time.

### DIFF
--- a/support/docker-volume-netshare
+++ b/support/docker-volume-netshare
@@ -13,21 +13,21 @@ set -e
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASE=$(basename $0)
+APP="docker-volume-netshare"
 
-# modify these in /etc/default/$BASE (/etc/default/dkv-netshare)
-DKV_NETSHARE=/usr/bin/$BASE
+# modify these in /etc/default/$APP (/etc/default/dkv-netshare)
+DKV_NETSHARE=/usr/bin/$APP
 # This is the pid file created/managed by start-stop-daemon
-DKV_NETSHARE_SSD_PIDFILE=/var/run/$BASE-ssd.pid
-DKV_NETSHARE_LOGFILE=/var/log/$BASE.log
+DKV_NETSHARE_SSD_PIDFILE=/var/run/$APP-ssd.pid
+DKV_NETSHARE_LOGFILE=/var/log/$APP.log
 DKV_NETSHARE_OPTS=
 DKV_NETSHARE_DESC="Docker-Volume-Netshare"
 
 # Get lsb functions
 . /lib/lsb/init-functions
 
-if [ -f /etc/default/$BASE ]; then
-	. /etc/default/$BASE
+if [ -f /etc/default/$APP ]; then
+	. /etc/default/$APP
 fi
 
 # Check docker is present
@@ -50,8 +50,8 @@ case "$1" in
 		touch "$DKV_NETSHARE_LOGFILE"
 		chgrp docker "$DKV_NETSHARE_LOGFILE"
 
-		
-		log_begin_msg "Starting $DKV_NETSHARE_DESC: $BASE"
+
+		log_begin_msg "Starting $DKV_NETSHARE_DESC: $APP"
 		start-stop-daemon --start --background \
 			--no-close \
 			--exec "$DKV_NETSHARE" \
@@ -65,7 +65,7 @@ case "$1" in
 
 	stop)
 		fail_unless_root
-		log_begin_msg "Stopping $DKV_NETSHARE_DESC: $BASE"
+		log_begin_msg "Stopping $DKV_NETSHARE_DESC: $APP"
 		start-stop-daemon --stop --pidfile "$DKV_NETSHARE_SSD_PIDFILE"
 		log_end_msg $?
 		;;

--- a/support/sysvinit-debian/etc/init.d/docker-volume-netshare
+++ b/support/sysvinit-debian/etc/init.d/docker-volume-netshare
@@ -13,21 +13,21 @@ set -e
 
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
-BASE=$(basename $0)
+APP="docker-volume-netshare"
 
-# modify these in /etc/default/$BASE (/etc/default/dkv-netshare)
-DKV_NETSHARE=/usr/bin/$BASE
+# modify these in /etc/default/$APP (/etc/default/dkv-netshare)
+DKV_NETSHARE=/usr/bin/$APP
 # This is the pid file created/managed by start-stop-daemon
-DKV_NETSHARE_SSD_PIDFILE=/var/run/$BASE-ssd.pid
-DKV_NETSHARE_LOGFILE=/var/log/$BASE.log
+DKV_NETSHARE_SSD_PIDFILE=/var/run/$APP-ssd.pid
+DKV_NETSHARE_LOGFILE=/var/log/$APP.log
 DKV_NETSHARE_OPTS=
 DKV_NETSHARE_DESC="Docker-Volume-Netshare"
 
 # Get lsb functions
 . /lib/lsb/init-functions
 
-if [ -f /etc/default/$BASE ]; then
-	. /etc/default/$BASE
+if [ -f /etc/default/$APP ]; then
+	. /etc/default/$APP
 fi
 
 # Check docker is present
@@ -50,8 +50,8 @@ case "$1" in
 		touch "$DKV_NETSHARE_LOGFILE"
 		chgrp docker "$DKV_NETSHARE_LOGFILE"
 
-		
-		log_begin_msg "Starting $DKV_NETSHARE_DESC: $BASE"
+
+		log_begin_msg "Starting $DKV_NETSHARE_DESC: $APP"
 		start-stop-daemon --start --background \
 			--no-close \
 			--exec "$DKV_NETSHARE" \
@@ -65,7 +65,7 @@ case "$1" in
 
 	stop)
 		fail_unless_root
-		log_begin_msg "Stopping $DKV_NETSHARE_DESC: $BASE"
+		log_begin_msg "Stopping $DKV_NETSHARE_DESC: $APP"
 		start-stop-daemon --stop --pidfile "$DKV_NETSHARE_SSD_PIDFILE"
 		log_end_msg $?
 		;;


### PR DESCRIPTION
Statically set the application name in the init scripts.

This allows the sysvinit scripts to be used at boot time. 

Currently the issue is that when you enable docker-volume-netshare with `update-rc.d docker-volume-netshare defaults` is that it create the symlinks under /etc/rc*.d as such `/etc/rc2.d/S20docker-volume-netshare`. This in turn causes the script to pickup `S20docker-volume-netshare` as BASE on boot and so docker-volume-netshare fails to startup with `/usr/bin/S20docker-volume-netshare not present or not executable`. 

This is not visible when doing `service docker-volume-netshare start` because in this case it uses /etc/init.d/docker-volume-netshare as and picks up `docker-volume-netshare` as BASE.