### PR TITLE
add NETSHAER_SOCKET_NAME to set the interface socket name

### DIFF
--- a/netshare/netshare.go
+++ b/netshare/netshare.go
@@ -45,6 +45,7 @@ const (
 	EnvNfsVers       = "NETSHARE_NFS_VERSION"
 	EnvTCP           = "NETSHARE_TCP_ENABLED"
 	EnvTCPAddr       = "NETSHARE_TCP_ADDR"
+	EnvSocketName    = "NETSHARE_SOCKET_NAME"
 	PluginAlias      = "netshare"
 	NetshareHelp     = `
 	docker-volume-netshare (NFS V3/4, AWS EFS and CIFS Volume Driver Plugin)
@@ -238,7 +239,11 @@ func start(dt drivers.DriverType, driver volume.Driver) {
 		}
 		fmt.Println(h.ServeTCP(dt.String(), addr, nil))
 	} else {
-		fmt.Println(h.ServeUnix(dt.String(), syscall.Getgid()))
+		socketName := os.Getenv(EnvSocketName)
+		if socketName == "" {
+			socketName = dt.String()
+		}
+		fmt.Println(h.ServeUnix(socketName, syscall.Getgid()))
 	}
 }
 


### PR DESCRIPTION
i have done [something ](https://github.com/wanghaibo/volume-netshare-plugin) to adapter v2 plugin architecture which need [static interface.socket  config ](https://docs.docker.com/engine/extend/config/#config-field-descriptions)

so  add an environment variable  NETSHARE_SOCKET_NAMEto do this