### PR TITLE
Volume connection counter increased by 2 when volume is already mounted

### DIFF
--- a/netshare/drivers/nfs.go
+++ b/netshare/drivers/nfs.go
@@ -57,7 +57,6 @@ func (n nfsDriver) Mount(r *volume.MountRequest) (*volume.MountResponse, error) 
 
 	if n.mountm.HasMount(resolvedName) && n.mountm.Count(resolvedName) > 0 {
 		log.Infof("Using existing NFS volume mount: %s", hostdir)
-		n.mountm.Increment(resolvedName)
 		if err := run(fmt.Sprintf("grep -c %s /proc/mounts", hostdir)); err != nil {
 			log.Infof("Existing NFS volume not mounted, force remount.")
 		} else {


### PR DESCRIPTION
When you try to assemble a volume already mounted, it seems the connections counter is increased by 2, which causes the last container never can unmount that volume due to the counter never reach 0.

I have test it and it seems that the last container can unmount the volume properly.

I encourage you to review it and change it as you like.