### PR TITLE
Fix Issue #188:  Restore mount options when recovering state

### DIFF
--- a/netshare/drivers/mounts.go
+++ b/netshare/drivers/mounts.go
@@ -170,8 +170,8 @@ func (m *MountManager) GetVolumes(rootPath string) []*volume.Volume {
 	return volumes
 }
 
-func (m *MountManager) AddMount(name string, hostdir string, connections int) {
-	m.mounts[name] = &mount{name: name, hostdir: hostdir, managed: true, connections: connections}
+func (m *MountManager) AddMount(name string, hostdir string, opts map[string]string, connections int) {
+	m.mounts[name] = &mount{name: name, hostdir: hostdir, managed: true, opts: opts, connections: connections}
 }
 
 //Checking volume references with started and stopped containers as well.

--- a/netshare/netshare.go
+++ b/netshare/netshare.go
@@ -303,7 +303,7 @@ func syncDockerState(driverName string) *drivers.MountManager {
 		}
 		connections := activeConnections(vol.Name)
 		log.Infof("Recovered state: %s , %s , %s , %s , %d ", vol.Name, vol.Mountpoint, vol.Driver, vol.CreatedAt, connections)
-		mount.AddMount(vol.Name, vol.Mountpoint, connections)
+		mount.AddMount(vol.Name, vol.Mountpoint, vol.Options, connections)
 	}
 	return mount
 }


### PR DESCRIPTION
Fix Issue #188 by restoring the mount options when recovering state.  They are already provided to us when we call the Docker volume list API call.